### PR TITLE
Bump version of o.e.pde.ui.templates

### DIFF
--- a/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.pde.ui.templates;singleton:=true
-Bundle-Version: 3.7.500.qualifier
+Bundle-Version: 3.7.600.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.pde.internal.ui.templates;x-internal:=true,

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/WorkspaceModelManagerTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/core/tests/internal/WorkspaceModelManagerTest.java
@@ -282,6 +282,7 @@ public class WorkspaceModelManagerTest {
 
 	private void setBundleRoot(IProject project, String path) throws CoreException {
 		PDEProject.setBundleRoot(project, path != null ? project.getFolder(path) : null);
+		project.build(IncrementalProjectBuilder.FULL_BUILD, null);
 	}
 
 	private void copyFile(IFile source, IFile target, UnaryOperator<String> modifications)


### PR DESCRIPTION
This was not done in PR #3 and likely not discovered due to the then missing verification build.