### PR TITLE
improve ClasspathUtilCore.getPath performance eclipse-pde#13

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/ClasspathUtilCore.java
@@ -221,7 +221,7 @@ public class ClasspathUtilCore {
 				return new Path(file.getAbsolutePath());
 			}
 			file = new File(libraryName);
-			if (file.exists() && file.isAbsolute()) {
+			if (file.isAbsolute() && file.exists()) {
 				return new Path(libraryName);
 			}
 		}


### PR DESCRIPTION
isAbsolute() is cheap, exists() is I/O. fail fast!