### PR TITLE
Replace Finalization by try-with-resource

### DIFF
--- a/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
+++ b/apitools/org.eclipse.pde.api.tools/src/org/eclipse/pde/api/tools/internal/util/Util.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1965,12 +1964,9 @@ public final class Util {
 	 * it doesn't exist)
 	 */
 	public static void guntar(String zipPath, String destDirPath) throws TarException, IOException {
-		TarFile tarFile = new TarFile(zipPath);
-		Enumeration<TarEntry> entries = tarFile.entries();
-		byte[] buf = new byte[8192];
-		for (; entries.hasMoreElements();) {
-			TarEntry zEntry;
-			while ((zEntry = entries.nextElement()) != null) {
+		try (TarFile tarFile = new TarFile(new File(zipPath))) {
+			byte[] buf = new byte[8192];
+			for (TarEntry zEntry : tarFile.entries()) {
 				// if it is empty directory, create it
 				if (zEntry.getFileType() == TarEntry.DIRECTORY) {
 					new File(destDirPath, zEntry.getName()).mkdirs();

--- a/ds/org.eclipse.pde.ds.core/META-INF/MANIFEST.MF
+++ b/ds/org.eclipse.pde.ds.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.ds.core;singleton:=true
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Activator: org.eclipse.pde.internal.ds.core.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
  org.eclipse.core.filebuffers;bundle-version="[3.3.0,4.0.0)",

--- a/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/builders/DefaultSAXParser.java
+++ b/ds/org.eclipse.pde.ds.core/src/org/eclipse/pde/internal/ds/core/builders/DefaultSAXParser.java
@@ -29,12 +29,8 @@ import org.xml.sax.SAXException;
 public class DefaultSAXParser {
 
 	public static void parse(IFile file, XMLErrorReporter reporter) {
-		SAXParserWrapper parser = null;
-		try {
-			parser = new SAXParserWrapper();
-			try (InputStream stream = new BufferedInputStream(file.getContents())) {
-				parser.parse(stream, reporter);
-			}
+		try (InputStream stream = new BufferedInputStream(file.getContents())) {
+			SAXParserWrapper.parse(stream, reporter);
 		} catch (CoreException | SAXException | IOException | ParserConfigurationException e) {
 		}
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/DefaultSAXParser.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/builders/DefaultSAXParser.java
@@ -25,12 +25,8 @@ import org.xml.sax.SAXException;
 public class DefaultSAXParser {
 
 	public static void parse(IFile file, XMLErrorReporter reporter) {
-		SAXParserWrapper parser = null;
-		try {
-			parser = new SAXParserWrapper();
-			try (InputStream stream = new BufferedInputStream(file.getContents())) {
-			parser.parse(stream, reporter);
-			}
+		try (InputStream stream = new BufferedInputStream(file.getContents())) {
+			SAXParserWrapper.parse(stream, reporter);
 		} catch (CoreException | SAXException | IOException | ParserConfigurationException e) {
 		}
 	}

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/Schema.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/schema/Schema.java
@@ -448,9 +448,8 @@ public class Schema extends PlatformObject implements ISchema {
 
 	public void load(InputStream stream) {
 		try {
-			SAXParserWrapper parser = new SAXParserWrapper();
 			XMLDefaultHandler handler = new XMLDefaultHandler(fAbbreviated);
-			parser.parse(stream, handler);
+			SAXParserWrapper.parse(stream, handler);
 			traverseDocumentTree(handler.getDocumentElement());
 		} catch (SAXException e) {
 			// ignore parse errors - 'loaded' will be false anyway

--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SchemaUtil.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/util/SchemaUtil.java
@@ -63,8 +63,7 @@ public class SchemaUtil {
 		try {
 			connection = getURLConnection(url);
 			try (InputStream input = connection.getInputStream()) {
-				SAXParserWrapper parser = new SAXParserWrapper();
-				parser.parse(input, handler);
+				SAXParserWrapper.parse(input, handler);
 			}
 		} catch (MalformedURLException | SAXException e) {
 			// Ignore

--- a/ui/org.eclipse.pde.core/src_ant/org/eclipse/pde/internal/core/ant/ConvertSchemaToHTML.java
+++ b/ui/org.eclipse.pde.core/src_ant/org/eclipse/pde/internal/core/ant/ConvertSchemaToHTML.java
@@ -95,12 +95,10 @@ public class ConvertSchemaToHTML extends Task {
 				continue;
 			}
 			Schema schema = null;
-			SAXParserWrapper parser = null;
 			try {
-				parser = new SAXParserWrapper();
 				File schemaFile = new File(model.getInstallLocation(), schemaLocation);
 				XMLDefaultHandler handler = new XMLDefaultHandler();
-				parser.parse(schemaFile, handler);
+				SAXParserWrapper.parse(schemaFile, handler);
 				URL url = schemaFile.toURL();
 				SchemaDescriptor desc = new SchemaDescriptor(extPoint.getFullId(), url, searchPaths);
 				schema = (Schema) desc.getSchema(false);

--- a/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/XMLEditingModel.java
+++ b/ui/org.eclipse.pde.core/text/org/eclipse/pde/internal/core/text/XMLEditingModel.java
@@ -48,8 +48,7 @@ public abstract class XMLEditingModel extends AbstractEditingModel {
 		try {
 			fLoaded = true;
 			status = Status.OK_STATUS;
-			SAXParserWrapper parser = new SAXParserWrapper();
-			parser.parse(source, createDocumentHandler(this, true));
+			SAXParserWrapper.parse(source, createDocumentHandler(this, true));
 		} catch (SAXException e) {
 			fLoaded = false;
 			status = Status.error(e.getMessage(), e);
@@ -68,8 +67,7 @@ public abstract class XMLEditingModel extends AbstractEditingModel {
 	@Override
 	public void adjustOffsets(IDocument document) {
 		try {
-			SAXParserWrapper parser = new SAXParserWrapper();
-			parser.parse(getInputStream(document), createDocumentHandler(this, false));
+			SAXParserWrapper.parse(getInputStream(document), createDocumentHandler(this, false));
 		} catch (SAXException | IOException | ParserConfigurationException | FactoryConfigurationError e) {
 		}
 	}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/performance/parts/SchemaTraversePerfTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/performance/parts/SchemaTraversePerfTest.java
@@ -42,9 +42,8 @@ public class SchemaTraversePerfTest extends AbstractSchemaPerfTest {
 	protected void executeTest() throws Exception {
 		URLConnection connection = SchemaUtil.getURLConnection(fXSDFile.toURI().toURL());
 		try (InputStream input = connection.getInputStream()) {
-			SAXParserWrapper parser = new SAXParserWrapper();
 			XMLDefaultHandler handler = new XMLDefaultHandler(true);
-			parser.parse(input, handler);
+			SAXParserWrapper.parse(input, handler);
 			EditableSchema schema = new EditableSchema("pluginID", "pointID", "name", true);
 			schema.traverseDocumentTree(handler.getDocumentElement());
 		} finally {

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/xml/ParserWrapperTestCase.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/util/xml/ParserWrapperTestCase.java
@@ -120,9 +120,7 @@ public class ParserWrapperTestCase {
 
 				try {
 					XMLDefaultHandler handler = new XMLDefaultHandler();
-					SAXParserWrapper parser = new SAXParserWrapper();
-					parser.parse(fParserXMLFile, handler);
-					parser.dispose();
+					SAXParserWrapper.parse(fParserXMLFile, handler);
 				} catch (ParserConfigurationException | SAXException | FactoryConfigurationError | IOException e) {
 					e.printStackTrace();
 					fError = true;


### PR DESCRIPTION
Finalization is deprecated for removal since [Java-18](https://openjdk.java.net/jeps/421) and there are already better alternatives with Java-11.

Together with PR #18 this removes all overwrites of Object.finalize in the PDE code base.

