### PR TITLE
Bug 579635 - NPE in MatchLocator.findIndexMatches(MatchLocator.java:306)

### DIFF
--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/FindClassResolutionsOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/correction/java/FindClassResolutionsOperation.java
@@ -299,6 +299,9 @@ public class FindClassResolutionsOperation implements IRunnableWithProgress {
 			};
 
 			SearchPattern typePattern = SearchPattern.createPattern(aTypeName, IJavaSearchConstants.TYPE, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+			if (typePattern == null) {
+				return Collections.emptyMap();
+			}
 			new SearchEngine().search(typePattern, new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()}, searchScope, requestor, subMonitor.split(1));
 
 			if (!packages.isEmpty()) {

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/AddNewDependenciesOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/AddNewDependenciesOperation.java
@@ -257,7 +257,14 @@ public class AddNewDependenciesOperation extends WorkspaceModifyOperation {
 						String pkgName = exported[i].getName();
 						if (!ignorePkgs.contains(pkgName)) {
 							ReferenceFinder requestor = new ReferenceFinder();
-							engine.search(SearchPattern.createPattern(pkgName, IJavaSearchConstants.PACKAGE, IJavaSearchConstants.REFERENCES, SearchPattern.R_EXACT_MATCH), new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()}, searchScope, requestor, null);
+							SearchPattern pattern = SearchPattern.createPattern(pkgName, IJavaSearchConstants.PACKAGE,
+									IJavaSearchConstants.REFERENCES, SearchPattern.R_EXACT_MATCH);
+							if (pattern == null) {
+								continue;
+							}
+							engine.search(pattern,
+									new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope,
+									requestor, null);
 							if (requestor.foundMatches()) {
 								fNewDependencies = true;
 								ignorePkgs.add(pkgName);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/DependencyExtentOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/DependencyExtentOperation.java
@@ -144,10 +144,20 @@ public class DependencyExtentOperation {
 			if (type.isAnonymous())
 				continue;
 			TypeReferenceSearchRequestor requestor = new TypeReferenceSearchRequestor();
-			engine.search(SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES), new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()}, scope, requestor, null);
+			SearchPattern pattern = SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES);
+			if (pattern == null) {
+				continue;
+			}
+			engine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, scope,
+					requestor, null);
 			if (requestor.containMatches()) {
 				TypeDeclarationSearchRequestor decRequestor = new TypeDeclarationSearchRequestor();
-				engine.search(SearchPattern.createPattern(type, IJavaSearchConstants.DECLARATIONS), new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()}, SearchEngine.createJavaSearchScope(new IJavaElement[] {parent}), decRequestor, null);
+				pattern = SearchPattern.createPattern(type, IJavaSearchConstants.DECLARATIONS);
+				if (pattern == null) {
+					continue;
+				}
+				engine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
+						SearchEngine.createJavaSearchScope(new IJavaElement[] { parent }), decRequestor, null);
 				Match match = decRequestor.getMatch();
 				if (match != null)
 					fSearchResult.addMatch(match);

--- a/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
+++ b/ui/org.eclipse.pde.ui/src/org/eclipse/pde/internal/ui/search/dependencies/GatherUnusedDependenciesOperation.java
@@ -171,7 +171,11 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 				SubMonitor iterationMonitor = subMonitor.split(2);
 				if (pkgFragment.hasChildren()) {
 					Requestor requestor = new Requestor();
-					engine.search(SearchPattern.createPattern(pkgFragment, IJavaSearchConstants.REFERENCES),
+					SearchPattern pattern = SearchPattern.createPattern(pkgFragment, IJavaSearchConstants.REFERENCES);
+					if (pattern == null) {
+						continue;
+					}
+					engine.search(pattern,
 							new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope,
 							requestor, iterationMonitor.split(1));
 					if (requestor.foundMatches()) {
@@ -204,7 +208,11 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 				SubMonitor iterationMonitor = subMonitor.split(1).setWorkRemaining(types.length);
 				for (IType type : types) {
 					requestor = new Requestor();
-					engine.search(SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES),
+					SearchPattern pattern = SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES);
+					if (pattern == null) {
+						continue;
+					}
+					engine.search(pattern,
 							new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope,
 							requestor, iterationMonitor.split(1));
 					if (requestor.foundMatches()) {
@@ -232,9 +240,13 @@ public class GatherUnusedDependenciesOperation implements IRunnableWithProgress 
 			Requestor requestor = new Requestor();
 			String packageName = pkg.getName();
 
+			SearchPattern pattern = SearchPattern.createPattern(packageName, IJavaSearchConstants.PACKAGE,
+					IJavaSearchConstants.REFERENCES, SearchPattern.R_EXACT_MATCH);
+			if (pattern == null) {
+				return false;
+			}
 			engine.search(
-					SearchPattern.createPattern(packageName, IJavaSearchConstants.PACKAGE,
-							IJavaSearchConstants.REFERENCES, SearchPattern.R_EXACT_MATCH),
+					pattern,
 					new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope, requestor,
 					subMonitor.split(1));
 


### PR DESCRIPTION
SearchPattern.createPattern() can return null pattern if the input is
not valid. So don't pass null patterns down to the Search engine, it
doesn't like that.