### PR TITLE
Remove asm from feature.xml

### DIFF
--- a/features/org.eclipse.pde-feature/feature.xml
+++ b/features/org.eclipse.pde-feature/feature.xml
@@ -79,20 +79,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.objectweb.asm"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.objectweb.asm.tree"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.pde.api.tools"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
ASM comes transitively from Required-Bundle of API Tools. So let's
remove it from feature to facilitate upgrades to newer version without
having to touch the feature.