### PR TITLE
Fix #30: fix check on missing requirements in Equinox preLaunchCheck()

### DIFF
--- a/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/RequirementHelper.java
+++ b/ui/org.eclipse.pde.launching/src/org/eclipse/pde/internal/launching/launcher/RequirementHelper.java
@@ -88,7 +88,7 @@ public class RequirementHelper {
 		String pluginResolution = isFeatureBasedLaunch ? configuration.getAttribute(IPDELauncherConstants.FEATURE_PLUGIN_RESOLUTION, IPDELauncherConstants.LOCATION_WORKSPACE) : IPDELauncherConstants.LOCATION_WORKSPACE;
 
 		List<String> appRequirements = getApplicationLaunchRequirements(configuration);
-		boolean missingRequirements = false;
+		boolean allRequirementsSatisfied = true;
 		for (String requiredBundleId : appRequirements) {
 			ModelEntry entry = PluginRegistry.findEntry(requiredBundleId);
 			if (entry != null) {
@@ -99,10 +99,10 @@ public class RequirementHelper {
 					addPlugin.accept(plugin);
 				}
 			} else {
-				missingRequirements = true;
+				allRequirementsSatisfied = false;
 			}
 		}
-		return missingRequirements;
+		return allRequirementsSatisfied;
 	}
 
 	public static List<String> getProductRequirements(ILaunchConfiguration config) throws CoreException {


### PR DESCRIPTION
This fixes #30.
`RequirementHelper.addApplicationLaunchRequirements()` now returns true if
all requirements are satisfied and false if requirements are missing.

Instead of reverting the return value of `addApplicationLaunchRequirements()` the if-condition in the callers could be reverted, but I think it is more meaningful and does align better e.g. with Java-standard Collection if true is returned in case all requirements are satisfied.